### PR TITLE
Mar6

### DIFF
--- a/src/main/java/org/g13_정렬/좌표압축.java
+++ b/src/main/java/org/g13_정렬/좌표압축.java
@@ -1,0 +1,32 @@
+package org.g13_정렬;
+
+import java.util.*;
+
+public class 좌표압축 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        int N = sc.nextInt();
+
+        int[] a = new int[N];
+        Set<Integer> s = new HashSet<>();
+
+        for (int i = 0; i < N; i++) {
+            a[i] = sc.nextInt();
+            s.add(a[i]);
+        }
+
+        List<Integer> l = new ArrayList<>(s);
+        Collections.sort(l);
+
+        Map<Integer, Integer> m = new HashMap<>();
+        for (int i = 0; i < l.size(); i++) {
+            m.put(l.get(i), i);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < N; i++) {
+            sb.append(m.get(a[i])).append(" ");
+        }
+        System.out.println(sb);
+    }
+}

--- a/src/main/java/org/g14_집합과_맵/문자열_집합.java
+++ b/src/main/java/org/g14_집합과_맵/문자열_집합.java
@@ -1,0 +1,34 @@
+package org.g14_집합과_맵;
+
+import java.io.*;
+import java.util.*;
+
+public class 문자열_집합 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        Set<String> set = new HashSet<>();
+
+        for (int i = 0; i < N; i++) {
+            set.add(br.readLine());
+        }
+
+        int result = 0;
+
+        for (int i = 0; i < M; i++) {
+            if (set.contains(br.readLine())) {
+                result++;
+            }
+        }
+
+        bw.write(String.valueOf(result));
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}

--- a/src/main/java/org/g14_집합과_맵/숫자_카드.java
+++ b/src/main/java/org/g14_집합과_맵/숫자_카드.java
@@ -1,0 +1,34 @@
+package org.g14_집합과_맵;
+
+import java.io.*;
+import java.util.*;
+
+public class 숫자_카드 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int N = Integer.parseInt(br.readLine());
+        Set<Integer> hasCards = new HashSet<>();
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            hasCards.add(Integer.parseInt(st.nextToken()));
+        }
+
+        int M = Integer.parseInt(br.readLine());
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < M; i++) {
+            if (hasCards.contains(Integer.parseInt(st.nextToken()))) {
+                bw.write("1 ");
+            } else {
+                bw.write("0 ");
+            }
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
## 좌표 압축
Map과 List로 풀다가 시간 초과로 오답 처리됨
-> Set으로 변경, StringBuilder 사용
### 성능을 고려하는 코드 구현의 중요성 체감

# 집합과 맵 챕터 진입

## 숫자 카드
이 문제부터 성능 및 속도를 위해 Scanner와 System.out.println, .split() 사용 중지
-> BufferedReader(InputStreamReader), BufferedWriter(OutputStreamWriter), StringTokenizer 사용
for 문 + Set contains 사용으로 풀이 후 정답
Set은 중복 불가 및 순서 보장 안 됨 특성으로 굳이 중복을 걸러야 하는 용도가 아니라면 잘 사용하지 않았는데 성능면에서 유리하므로 잘 사용해 봐야겠다

## 문자열 집합
위 문제와 동일한 방법으로 풀이
비교군이 공백 (" ") 으로 구분되어 있었던 데 비해 이번에는 개행되어 있다는 것,
Integer 가 String이 된 것 외에 크게 다른 점 없음